### PR TITLE
feat: Tag component

### DIFF
--- a/src/Tag/Tag.tsx
+++ b/src/Tag/Tag.tsx
@@ -4,6 +4,7 @@ import { Clickable, CompositeItem, CompositeStateReturn } from "reakit";
 import theme from "../theme";
 import { ocx } from "../utils";
 import { CrossIcon } from "../icons";
+import { Box, BoxProps } from "../box";
 import { forwardRefWithAs, PropsWithAs } from "../utils/types";
 
 export const TagsContext = React.createContext<CompositeStateReturn | null>(
@@ -13,7 +14,7 @@ export const useTagsContext = () => {
   return React.useContext(TagsContext);
 };
 
-export type TagProps = {
+export type TagProps = Omit<BoxProps, "prefix"> & {
   /**
    * id for the tag
    */
@@ -78,9 +79,9 @@ function TagComponent(
   );
 
   return (
-    <span ref={ref} className={tagStyles} {...rest}>
+    <Box as="span" ref={ref} className={tagStyles} {...rest}>
       <TagWithPrefixSuffix />
-    </span>
+    </Box>
   );
 }
 

--- a/src/Tag/Tag.tsx
+++ b/src/Tag/Tag.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+
+import theme from "../theme";
+import { ocx } from "../utils";
+import { forwardRefWithAs, PropsWithAs } from "../utils/types";
+
+export type TagProps = {
+  /**
+   * How large should the button be?
+   */
+  size?: "xs" | "sm" | "md" | "lg";
+  /**
+   * If added, the button will show an icon before the button's label.
+   */
+  prefix?: React.ReactElement;
+  /**
+   * If added, the button will show an icon before the button's label.
+   */
+  postfix?: React.ReactElement;
+};
+
+function TagComponent(
+  props: PropsWithAs<TagProps, "span">,
+  ref: React.Ref<HTMLSpanElement>,
+) {
+  const { size = "md", prefix, postfix, className, children, ...rest } = props;
+  const tagStyles = ocx(theme.tag.base, theme.tag.size[size], className);
+
+  const TagWithPrefixPostfix = () => (
+    <>
+      {prefix && <span className={theme.tag.prefix}>{prefix}</span>}
+      {children}
+      {postfix && <span className={theme.tag.postfix}>{postfix}</span>}
+    </>
+  );
+
+  return (
+    <span ref={ref} className={tagStyles} {...rest}>
+      <TagWithPrefixPostfix />
+    </span>
+  );
+}
+
+export const Tag = forwardRefWithAs<TagProps, "span">(TagComponent);

--- a/src/Tag/Tag.tsx
+++ b/src/Tag/Tag.tsx
@@ -31,11 +31,12 @@ export type TagProps = {
    */
   size?: "xs" | "sm" | "md" | "lg";
   /**
-   * If added, the button will show an icon before the button's label.
+   * If added, tag will show prefix the content before the tag's label
    */
   prefix?: React.ReactElement;
   /**
-   * If added, the button will show an icon before the button's label.
+   * If added, tag will show suffix after the tag's label.
+   * NOTE: This will only show if closable is set to `true`
    */
   suffix?: React.ReactElement;
 };
@@ -56,6 +57,13 @@ function TagComponent(
     ...rest
   } = props;
   const tagStyles = ocx(theme.tag.base, theme.tag.size[size], className);
+
+  console.log(suffix, closable);
+  if (!closable && !(suffix instanceof CrossIcon)) {
+    console.warn(
+      "Tag: `suffix` will not be visible because `closable` is set to false, please set `closable` to true",
+    );
+  }
 
   const TagWithPrefixSuffix = () => (
     <>

--- a/src/Tag/Tag.tsx
+++ b/src/Tag/Tag.tsx
@@ -58,8 +58,8 @@ function TagComponent(
   } = props;
   const tagStyles = ocx(theme.tag.base, theme.tag.size[size], className);
 
-  console.log(suffix, closable);
-  if (!closable && !(suffix instanceof CrossIcon)) {
+  // TODO: Clean this up
+  if (!closable && suffix.type.displayName !== (CrossIcon as any).displayName) {
     console.warn(
       "Tag: `suffix` will not be visible because `closable` is set to false, please set `closable` to true",
     );

--- a/src/Tag/Tag.tsx
+++ b/src/Tag/Tag.tsx
@@ -1,10 +1,31 @@
 import React from "react";
+import { Clickable, CompositeItem, CompositeStateReturn } from "reakit";
 
 import theme from "../theme";
 import { ocx } from "../utils";
+import { CrossIcon } from "../icons";
 import { forwardRefWithAs, PropsWithAs } from "../utils/types";
 
+export const TagsContext = React.createContext<CompositeStateReturn | null>(
+  null,
+);
+export const useTagsContext = () => {
+  return React.useContext(TagsContext);
+};
+
 export type TagProps = {
+  /**
+   * id for the tag
+   */
+  id?: string;
+  /**
+   * Is tag closable?
+   */
+  closable?: boolean;
+  /**
+   * Callback to fire when close icon is clicked?
+   */
+  onClose?: (id?: string) => void;
   /**
    * How large should the button be?
    */
@@ -16,29 +37,60 @@ export type TagProps = {
   /**
    * If added, the button will show an icon before the button's label.
    */
-  postfix?: React.ReactElement;
+  suffix?: React.ReactElement;
 };
 
 function TagComponent(
   props: PropsWithAs<TagProps, "span">,
   ref: React.Ref<HTMLSpanElement>,
 ) {
-  const { size = "md", prefix, postfix, className, children, ...rest } = props;
+  const {
+    id,
+    size = "md",
+    prefix,
+    suffix = <CrossIcon />,
+    className,
+    closable,
+    onClose,
+    children,
+    ...rest
+  } = props;
   const tagStyles = ocx(theme.tag.base, theme.tag.size[size], className);
 
-  const TagWithPrefixPostfix = () => (
+  const TagWithPrefixSuffix = () => (
     <>
       {prefix && <span className={theme.tag.prefix}>{prefix}</span>}
       {children}
-      {postfix && <span className={theme.tag.postfix}>{postfix}</span>}
+      {closable && suffix && (
+        <ClosableElement handleClick={() => onClose?.(id)}>
+          {suffix}
+        </ClosableElement>
+      )}
     </>
   );
 
   return (
     <span ref={ref} className={tagStyles} {...rest}>
-      <TagWithPrefixPostfix />
+      <TagWithPrefixSuffix />
     </span>
   );
 }
 
 export const Tag = forwardRefWithAs<TagProps, "span">(TagComponent);
+
+const ClosableElement: React.FC<{
+  handleClick: () => void;
+}> = ({ handleClick, children }) => {
+  const composite = useTagsContext();
+
+  return (
+    <CompositeItem
+      as={Clickable}
+      className={theme.tag.suffix}
+      onClick={handleClick}
+      {...(composite ? composite : {})}
+    >
+      {children}
+    </CompositeItem>
+  );
+};

--- a/src/Tag/TagGroup.tsx
+++ b/src/Tag/TagGroup.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+import { Box } from "../box";
+import { Composite, useCompositeState } from "reakit";
+import { TagsContext } from ".";
+
+export type TagGroupProps = {
+  allowArrowNavigation?: boolean;
+  className?: string;
+};
+
+export const TagGroup: React.FC<TagGroupProps> = ({
+  children,
+  allowArrowNavigation = false,
+  ...props
+}) => {
+  const composite = useCompositeState();
+
+  return allowArrowNavigation ? (
+    <TagsContext.Provider value={composite}>
+      <Composite {...composite} role="group" aria-label="Tags group" {...props}>
+        {children}
+      </Composite>
+    </TagsContext.Provider>
+  ) : (
+    <Box as="div" role="group" aria-label="Tags group" {...props}>
+      {children}
+    </Box>
+  );
+};
+
+export default TagGroup;

--- a/src/Tag/TagGroup.tsx
+++ b/src/Tag/TagGroup.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
-import { Box } from "../box";
 import { Composite, useCompositeState } from "reakit";
-import { TagsContext } from ".";
+
+import { Box } from "../box";
+import { TagsContext } from "./Tag";
 
 export type TagGroupProps = {
   allowArrowNavigation?: boolean;

--- a/src/Tag/index.ts
+++ b/src/Tag/index.ts
@@ -1,0 +1,1 @@
+export * from "./Tag";

--- a/src/Tag/index.ts
+++ b/src/Tag/index.ts
@@ -1,1 +1,2 @@
 export * from "./Tag";
+export * from "./TagGroup";

--- a/src/Tag/stories/Tag.stories.tsx
+++ b/src/Tag/stories/Tag.stories.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { Story, Meta } from "@storybook/react/types-6-0";
+
+import "./tag.css";
+import { Tag, TagProps } from "../index";
+import {
+  ClockIcon,
+  CrossIcon,
+  WheelIcon,
+  PhotographIcon,
+  ArrowNarrowRightIcon,
+} from "../../icons";
+
+export default {
+  title: "Tag",
+  component: Tag,
+} as Meta;
+
+const DStory: Story<TagProps> = args => (
+  <Tag as="a" {...args}>
+    Tag
+  </Tag>
+);
+
+export const Default = DStory.bind({});
+Default.args = { size: "md" };
+
+const IStory: Story<TagProps> = args => (
+  <Tag {...args}>
+    <WheelIcon />
+  </Tag>
+);
+
+export const IButton = IStory.bind({});
+IButton.args = { size: "md" };
+
+const LIStory: Story<TagProps> = args => (
+  <Tag prefix={<ClockIcon />} {...args}>
+    Tag
+  </Tag>
+);
+
+export const LIButton = LIStory.bind({});
+LIButton.args = { size: "md" };
+
+const RIStory: Story<TagProps> = args => (
+  <Tag postfix={<ArrowNarrowRightIcon />} {...args}>
+    Tag
+  </Tag>
+);
+
+export const RIButton = RIStory.bind({});
+RIButton.args = { size: "md" };
+
+const BIStory: Story<TagProps> = args => (
+  <Tag prefix={<PhotographIcon />} postfix={<CrossIcon />} {...args}>
+    Tag
+  </Tag>
+);
+
+export const BIButton = BIStory.bind({});
+BIButton.args = { size: "md" };
+
+export const LStory: Story<TagProps> = args => (
+  <Tag prefix={<PhotographIcon />} postfix={<CrossIcon />} {...args}>
+    Tag
+  </Tag>
+);

--- a/src/Tag/stories/Tag.stories.tsx
+++ b/src/Tag/stories/Tag.stories.tsx
@@ -3,22 +3,17 @@ import { Story, Meta } from "@storybook/react/types-6-0";
 
 import "./tag.css";
 import { Tag, TagGroup, TagProps } from "../index";
-import {
-  ClockIcon,
-  CrossIcon,
-  PhotographIcon,
-  ArrowNarrowRightIcon,
-} from "../../icons";
+import { ClockIcon, PhotographIcon } from "../../icons";
 
 export default {
   title: "Tag",
   component: Tag,
 } as Meta;
 
-const DStory: Story<TagProps> = args => <Tag {...args}>Tag</Tag>;
+const Component: Story<TagProps> = args => <Tag {...args}>Tag</Tag>;
 
-export const Default = DStory.bind({});
-Default.args = { size: "md", closable: true, onClose: () => alert(1) };
+export const Default = Component.bind({});
+Default.args = { size: "md", onClose: () => alert(1) };
 
 export const GroupArrowNavigation = () => {
   return (
@@ -48,6 +43,7 @@ export const TagsExample = () => {
       {tags.map(tag => (
         <Tag
           closable
+          key={tag}
           id={tag}
           onClose={id => setTags(tags.filter(t => t !== id))}
         >
@@ -58,35 +54,18 @@ export const TagsExample = () => {
   );
 };
 
-const LIStory: Story<TagProps> = args => (
-  <Tag prefix={<ClockIcon />} {...args}>
-    Tag
-  </Tag>
-);
+export const PrefixIcon = Default.bind({});
+PrefixIcon.args = { prefix: <ClockIcon /> };
 
-export const LIButton = LIStory.bind({});
-LIButton.args = { size: "md" };
+export const SuffixIcon = Default.bind({});
+SuffixIcon.args = { closable: true, suffix: <PhotographIcon /> };
 
-const RIStory: Story<TagProps> = args => (
-  <Tag suffix={<ArrowNarrowRightIcon />} {...args}>
-    Tag
-  </Tag>
-);
+export const PrefixSuffixIcon = Default.bind({});
+PrefixSuffixIcon.args = {
+  closable: true,
+  prefix: <ClockIcon />,
+  suffix: <PhotographIcon />,
+};
 
-export const RIButton = RIStory.bind({});
-RIButton.args = { size: "md" };
-
-const BIStory: Story<TagProps> = args => (
-  <Tag closable onClose={() => alert(1)}>
-    Tag
-  </Tag>
-);
-
-export const BIButton = BIStory.bind({});
-BIButton.args = { size: "md" };
-
-export const LStory: Story<TagProps> = args => (
-  <Tag prefix={<PhotographIcon />} suffix={<CrossIcon />} {...args}>
-    Tag
-  </Tag>
-);
+export const Closable = Default.bind({});
+Closable.args = { closable: true, onClose: () => alert("Removed") };

--- a/src/Tag/stories/Tag.stories.tsx
+++ b/src/Tag/stories/Tag.stories.tsx
@@ -2,11 +2,10 @@ import React from "react";
 import { Story, Meta } from "@storybook/react/types-6-0";
 
 import "./tag.css";
-import { Tag, TagProps } from "../index";
+import { Tag, TagGroup, TagProps } from "../index";
 import {
   ClockIcon,
   CrossIcon,
-  WheelIcon,
   PhotographIcon,
   ArrowNarrowRightIcon,
 } from "../../icons";
@@ -16,23 +15,48 @@ export default {
   component: Tag,
 } as Meta;
 
-const DStory: Story<TagProps> = args => (
-  <Tag as="a" {...args}>
-    Tag
-  </Tag>
-);
+const DStory: Story<TagProps> = args => <Tag {...args}>Tag</Tag>;
 
 export const Default = DStory.bind({});
-Default.args = { size: "md" };
+Default.args = { size: "md", closable: true, onClose: () => alert(1) };
 
-const IStory: Story<TagProps> = args => (
-  <Tag {...args}>
-    <WheelIcon />
-  </Tag>
-);
+export const GroupArrowNavigation = () => {
+  return (
+    <TagGroup allowArrowNavigation className="flex items-center gap-1">
+      <Tag closable>Tag 1</Tag>
+      <Tag closable>Tag 2</Tag>
+      <Tag closable>Tag 3</Tag>
+    </TagGroup>
+  );
+};
 
-export const IButton = IStory.bind({});
-IButton.args = { size: "md" };
+export const GroupNoArrowNavigation = () => {
+  return (
+    <TagGroup className="flex items-center gap-1">
+      <Tag closable>Tag 1</Tag>
+      <Tag closable>Tag 2</Tag>
+      <Tag closable>Tag 3</Tag>
+    </TagGroup>
+  );
+};
+
+export const TagsExample = () => {
+  const [tags, setTags] = React.useState(["One", "Two", "Three"]);
+
+  return (
+    <TagGroup allowArrowNavigation className="flex items-center gap-1">
+      {tags.map(tag => (
+        <Tag
+          closable
+          id={tag}
+          onClose={id => setTags(tags.filter(t => t !== id))}
+        >
+          {tag}
+        </Tag>
+      ))}
+    </TagGroup>
+  );
+};
 
 const LIStory: Story<TagProps> = args => (
   <Tag prefix={<ClockIcon />} {...args}>
@@ -44,7 +68,7 @@ export const LIButton = LIStory.bind({});
 LIButton.args = { size: "md" };
 
 const RIStory: Story<TagProps> = args => (
-  <Tag postfix={<ArrowNarrowRightIcon />} {...args}>
+  <Tag suffix={<ArrowNarrowRightIcon />} {...args}>
     Tag
   </Tag>
 );
@@ -53,7 +77,7 @@ export const RIButton = RIStory.bind({});
 RIButton.args = { size: "md" };
 
 const BIStory: Story<TagProps> = args => (
-  <Tag prefix={<PhotographIcon />} postfix={<CrossIcon />} {...args}>
+  <Tag closable onClose={() => alert(1)}>
     Tag
   </Tag>
 );
@@ -62,7 +86,7 @@ export const BIButton = BIStory.bind({});
 BIButton.args = { size: "md" };
 
 export const LStory: Story<TagProps> = args => (
-  <Tag prefix={<PhotographIcon />} postfix={<CrossIcon />} {...args}>
+  <Tag prefix={<PhotographIcon />} suffix={<CrossIcon />} {...args}>
     Tag
   </Tag>
 );

--- a/src/Tag/stories/tag.css
+++ b/src/Tag/stories/tag.css
@@ -1,0 +1,5 @@
+@import "tailwindcss/base";
+
+@import "tailwindcss/components";
+
+@import "tailwindcss/utilities";

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -31,6 +31,18 @@ const theme = {
       xl: "h-12 w-12",
     },
   },
+  tag: {
+    base:
+      "font-sans font-semibold bg-gray-100 text-gray-800 inline-flex items-center justify-center appearance-none rounded-md transition-all relative whitespace-nowrap align-middle outline-none w-auto select-none disabled:cursor-not-allowed disabled:opacity-40",
+    prefix: "flex mr-2",
+    postfix: "flex ml-2",
+    size: {
+      xs: "h-6 min-w-6 text-xs px-2",
+      sm: "h-8 min-w-8 text-sm px-3",
+      md: "h-10 min-w-10 text-base px-4",
+      lg: "h-12 min-w-12 text-lg px-6",
+    },
+  },
 };
 
 export default theme;

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -35,7 +35,7 @@ const theme = {
     base:
       "font-sans font-semibold bg-gray-100 text-gray-800 inline-flex items-center justify-center appearance-none rounded-md transition-all relative whitespace-nowrap align-middle outline-none w-auto select-none disabled:cursor-not-allowed disabled:opacity-40",
     prefix: "flex mr-2",
-    postfix: "flex ml-2",
+    suffix: "flex ml-2",
     size: {
       xs: "h-6 min-w-6 text-xs px-2",
       sm: "h-8 min-w-8 text-sm px-3",


### PR DESCRIPTION
### Tag Component

References:
Ant Design : https://ant.design/components/tag
Vercel: https://vercel.com/design/tag
UI Patterns: http://ui-patterns.com/patterns/Tag

Although Tag component looks same as our Button component with icons on both sides and content. Use cases and the API can be a bit different since Tag is a closable/removable item.

#### When to use:
- Organizing/Categorizing based on tags
- Adding filters with removable tags

#### Props
- closable - boolean | default - false
- prefix - ReactNode | default - null
- suffix - ReactNode | default - `<CloseIcon />`
- onClose - (id) => void | callback to fire on close icon is clicked

By default Tag component will have x close icon in the suffix if the closable prop is true.


#### API

```tsx
<Tag prefix={<UserIcon />} closable onClose={() => alert(1)}>
  Tag
</Tag>
```

Change suffix icon

```tsx
<Tag suffix={<UserIcon />} closable onClose={() => alert(1)}>
  Tag
</Tag>
```

#### TagGroup

Reference: https://vercel.com/design/tag

We can also add a TagGroup component to handle the keyboard logic for the multiple tags
Ideally TagGroup will be a composite which would allows users to navigate the tags icons with ArrowLeft/Right
Note: The state logic for removing/adding the tags will be handled by the user not us.

#### Props

- allowArrowNavigation - boolean | if true will enable arrow navigation for the close icons

```tsx
const [tags, setTags] = useState(['One', 'Two', 'Three'])
return (
  <TagGroup>
    {tags.map(tag => (
      <Tag
        id={tag}
        key={tag}
        onClose={id => setTags(tags.filter(t => t !== id))}
  >    
        {tag}
      </Tag>
    ))}
  </TagGroup>
)
```