### PR TITLE
Fix: 💄Remove default browser onclick and onfocus outline on buttons,icons,input fields and checkboxes.

### DIFF
--- a/src/theme/defaultTheme/button.ts
+++ b/src/theme/defaultTheme/button.ts
@@ -1,6 +1,6 @@
 export const button = {
   base:
-    "lib:inline-flex lib:items-center lib:justify-center lib:appearance-none lib:transition-all lib:whitespace-nowrap lib:align-middle lib:select-none",
+    "lib:inline-flex lib:items-center lib:justify-center lib:appearance-none lib:transition-all lib:whitespace-nowrap lib:align-middle lib:select-none lib:outline-none lib:focus:outline-none",
   size: {
     sm:
       "lib:h-6 lib:w-auto lib:min-w-6 lib:px-2 lib:text-xs lib:font-medium lib:rounded-md",

--- a/src/theme/defaultTheme/buttonGroup.ts
+++ b/src/theme/defaultTheme/buttonGroup.ts
@@ -1,5 +1,6 @@
 export const buttonGroup = {
-  base: "lib:inline-flex lib:rounded-lg",
+  base:
+    "lib:inline-flex lib:rounded-lg lib:outline-none lib:focus:outline-none",
   attached: "lib:collapse-border",
   notAttached: "lib:space-x-1",
 };

--- a/src/theme/defaultTheme/checkbox.ts
+++ b/src/theme/defaultTheme/checkbox.ts
@@ -1,6 +1,6 @@
 export const checkbox = {
   base:
-    "lib:relative lib:inline-flex lib:items-center lib:align-top lib:cursor-pointer",
+    "lib:relative lib:inline-flex lib:items-center lib:align-top lib:cursor-pointer lib:outline-none lib:focus:outline-none",
   disabled: "lib:cursor-not-allowed",
   input: "lib:sr-only",
   icon: {

--- a/src/theme/defaultTheme/form-field.ts
+++ b/src/theme/defaultTheme/form-field.ts
@@ -1,6 +1,6 @@
 export const formField = {
   wrapper: {
-    base: "flex flex-col space-y-2",
+    base: "flex flex-col space-y-2 lib:outline-none lib:focus:outline-none",
     size: {},
   },
   labelText: "text-xs text-gray-900 inline-flex items-center justify-between",

--- a/src/theme/defaultTheme/radio.ts
+++ b/src/theme/defaultTheme/radio.ts
@@ -1,6 +1,6 @@
 export const radio = {
   base:
-    "lib:relative lib:inline-flex lib:items-center lib:align-top lib:cursor-pointer",
+    "lib:relative lib:inline-flex lib:items-center lib:align-top lib:cursor-pointer lib:outline-none lib:focus:outline-none",
   disabled: "lib:cursor-not-allowed",
   input: "lib:sr-only",
   icon: {

--- a/src/theme/defaultTheme/switch.ts
+++ b/src/theme/defaultTheme/switch.ts
@@ -16,7 +16,7 @@ export const _switch = {
     },
     content: {
       base:
-        "lib:transition-transform lib:transform lib:bg-white lib:rounded-full lib:shadow",
+        "lib:transition-transform lib:transform lib:bg-white lib:rounded-full lib:shadow lib:outline-none lib:focus:outline-none",
       size: {
         sm: "lib:h-2.5 lib:w-2.5",
         md: "lib:h-3 lib:w-3",

--- a/src/theme/defaultTheme/textarea.ts
+++ b/src/theme/defaultTheme/textarea.ts
@@ -1,6 +1,6 @@
 export const textarea = {
   base:
-    "lib:border lib:border-gray-300 lib:rounded lib:shadow-sm lib:p-3 lib:placeholder-gray-400 lib:text-xs lib:text-gray-800 lib:bg-white lib:hover:border-gray-400 lib:focus:outline-none lib:focus:border-blue-500 lib:focus:shadow-input lib:disabled:bg-gray-100 lib:disabled:border-gray-300 lib:disabled:text-gray-400 lib:disabled:cursor-not-allowed",
+    "lib:border lib:border-gray-300 lib:rounded lib:shadow-sm lib:p-3 lib:placeholder-gray-400 lib:text-xs lib:text-gray-800 lib:bg-white lib:hover:border-gray-400 lib:focus:outline-none lib:focus:border-blue-500 lib:focus:shadow-input lib:disabled:bg-gray-100 lib:disabled:border-gray-300 lib:disabled:text-gray-400 lib:disabled:cursor-not-allowed lib:outline-none lib:focus:outline-none",
   resize: {
     horizontal: "lib:resize-x",
     vertical: "lib:resize-y",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2156,24 +2156,6 @@
     regenerator-runtime "^0.13.7"
     ts-dedent "^2.0.0"
 
-"@storybook/addon-links@^6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-links/-/addon-links-6.2.1.tgz#64a9978b9eaec8a85de8b965d823cf5786c1a6ba"
-  integrity sha512-ZVAaNEVdQaL8+OLu6A7yfake0w8cn9YOZAnUcrIPalIVZ7MESy/vfxAE7lzYk17ngC9G+w5ELtzoD4WThTcCNg==
-  dependencies:
-    "@storybook/addons" "6.2.1"
-    "@storybook/client-logger" "6.2.1"
-    "@storybook/core-events" "6.2.1"
-    "@storybook/csf" "0.0.1"
-    "@storybook/router" "6.2.1"
-    "@types/qs" "^6.9.5"
-    core-js "^3.8.2"
-    global "^4.4.0"
-    prop-types "^15.7.2"
-    qs "^6.10.0"
-    regenerator-runtime "^0.13.7"
-    ts-dedent "^2.0.0"
-
 "@storybook/addon-postcss@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@storybook/addon-postcss/-/addon-postcss-2.0.0.tgz#ec61cb9bb2662f408072b35c466c7df801c28498"


### PR DESCRIPTION
Remove default browser onclick and onfocus outline on buttons,icons, input fields and checkboxes.

⚠No breaking changes.